### PR TITLE
[cvefeed] add -desc option

### DIFF
--- a/cmd/cpe2cve/cpe2cve.go
+++ b/cmd/cpe2cve/cpe2cve.go
@@ -34,17 +34,18 @@ import (
 )
 
 type config struct {
-	nProcessors                                     int
-	cpesAt, cvesAt, matchesAt                       int
-	cwesAt, cvss2at, cvss3at, cvssAt, descriptionAt int
-	inFieldSep, inRecSep                            string
-	outFieldSep, outRecSep                          string
-	cpuProfile, memProfile                          string
-	skip                                            fieldsToSkip
-	indexedDict                                     bool
-	requireVersion                                  bool
-	cacheSize                                       int64
-	overrides                                       multiString
+	nProcessors               int
+	cpesAt, cvesAt, matchesAt int
+	cwesAt, cvss2at, cvss3at  int
+	cvssAt, descAt            int
+	inFieldSep, inRecSep      string
+	outFieldSep, outRecSep    string
+	cpuProfile, memProfile    string
+	skip                      fieldsToSkip
+	indexedDict               bool
+	requireVersion            bool
+	cacheSize                 int64
+	overrides                 multiString
 }
 
 func (c *config) addFlags() {
@@ -52,11 +53,11 @@ func (c *config) addFlags() {
 	flag.IntVar(&c.cpesAt, "cpe", 0, "look for CPE names in input at this position (starts with 1)")
 	flag.IntVar(&c.cvesAt, "cve", 0, "output CVEs at this position (starts with 1)")
 	flag.IntVar(&c.cwesAt, "cwe", 0, "output problem types (CWEs) at this position (starts with 1)")
-	flag.IntVar(&c.descriptionAt, "description", 0, "output CVE description at this position (starts with 1)")
 	flag.IntVar(&c.cvssAt, "cvss", 0, "output CVSS base score (v3 if available, v2 otherwise) at this position (starts with 1)")
 	flag.IntVar(&c.cvss2at, "cvss2", 0, "output CVSS 2.0 base score at this position (starts with 1)")
 	flag.IntVar(&c.cvss3at, "cvss3", 0, "output CVSS 3.0 base score at this position (starts with 1)")
 	flag.IntVar(&c.matchesAt, "matches", 0, "output CPEs that matches CVE at this position; 0 disables the output")
+	flag.IntVar(&c.descAt, "desc", 0, "output CVE plain-text description at this position (starts with 1)")
 	flag.Int64Var(&c.cacheSize, "cache_size", 0, "limit the cache size to this amount in bytes; 0 removes the limit, -1 disables caching")
 	flag.StringVar(&c.inFieldSep, "d", "\t", "input columns delimiter")
 	flag.StringVar(&c.inRecSep, "d2", ",", "inner input columns delimiter: separates elements of list passed into a CSV columns")
@@ -91,8 +92,8 @@ func (c *config) mustBeValid() {
 		glog.Errorf("-cwe value is invalid %d", c.cwesAt)
 		flag.Usage()
 	}
-	if c.descriptionAt < 0 {
-		glog.Errorf("-description value is invalid %d", c.descriptionAt)
+	if c.descAt < 0 {
+		glog.Errorf("-desc value is invalid %d", c.descAt)
 		flag.Usage()
 	}
 	if c.cvss2at < 0 {
@@ -147,7 +148,7 @@ func process(in <-chan []string, out chan<- []string, cache *cvefeed.Cache, cfg 
 				cfg.cvesAt-1, matches.CVE.CVEID(),
 				cfg.matchesAt-1, strings.Join(matchingCPEs, cfg.outRecSep),
 				cfg.cwesAt-1, strings.Join(matches.CVE.ProblemTypes(), cfg.outRecSep),
-				cfg.descriptionAt-1, matches.CVE.Description(),
+				cfg.descAt-1, matches.CVE.Description(),
 				cfg.cvss2at-1, fmt.Sprintf("%.1f", matches.CVE.CVSS20base()),
 				cfg.cvss3at-1, fmt.Sprintf("%.1f", matches.CVE.CVSS30base()),
 				cfg.cvssAt-1, fmt.Sprintf("%.1f", cvss),

--- a/cmd/cpe2cve/cpe2cve.go
+++ b/cmd/cpe2cve/cpe2cve.go
@@ -34,17 +34,17 @@ import (
 )
 
 type config struct {
-	nProcessors                      int
-	cpesAt, cvesAt, matchesAt        int
-	cwesAt, cvss2at, cvss3at, cvssAt int
-	inFieldSep, inRecSep             string
-	outFieldSep, outRecSep           string
-	cpuProfile, memProfile           string
-	skip                             fieldsToSkip
-	indexedDict                      bool
-	requireVersion                   bool
-	cacheSize                        int64
-	overrides                        multiString
+	nProcessors                                     int
+	cpesAt, cvesAt, matchesAt                       int
+	cwesAt, cvss2at, cvss3at, cvssAt, descriptionAt int
+	inFieldSep, inRecSep                            string
+	outFieldSep, outRecSep                          string
+	cpuProfile, memProfile                          string
+	skip                                            fieldsToSkip
+	indexedDict                                     bool
+	requireVersion                                  bool
+	cacheSize                                       int64
+	overrides                                       multiString
 }
 
 func (c *config) addFlags() {
@@ -52,6 +52,7 @@ func (c *config) addFlags() {
 	flag.IntVar(&c.cpesAt, "cpe", 0, "look for CPE names in input at this position (starts with 1)")
 	flag.IntVar(&c.cvesAt, "cve", 0, "output CVEs at this position (starts with 1)")
 	flag.IntVar(&c.cwesAt, "cwe", 0, "output problem types (CWEs) at this position (starts with 1)")
+	flag.IntVar(&c.descriptionAt, "description", 0, "output CVE description at this position (starts with 1)")
 	flag.IntVar(&c.cvssAt, "cvss", 0, "output CVSS base score (v3 if available, v2 otherwise) at this position (starts with 1)")
 	flag.IntVar(&c.cvss2at, "cvss2", 0, "output CVSS 2.0 base score at this position (starts with 1)")
 	flag.IntVar(&c.cvss3at, "cvss3", 0, "output CVSS 3.0 base score at this position (starts with 1)")
@@ -88,6 +89,10 @@ func (c *config) mustBeValid() {
 	}
 	if c.cwesAt < 0 {
 		glog.Errorf("-cwe value is invalid %d", c.cwesAt)
+		flag.Usage()
+	}
+	if c.descriptionAt < 0 {
+		glog.Errorf("-description value is invalid %d", c.descriptionAt)
 		flag.Usage()
 	}
 	if c.cvss2at < 0 {
@@ -142,6 +147,7 @@ func process(in <-chan []string, out chan<- []string, cache *cvefeed.Cache, cfg 
 				cfg.cvesAt-1, matches.CVE.CVEID(),
 				cfg.matchesAt-1, strings.Join(matchingCPEs, cfg.outRecSep),
 				cfg.cwesAt-1, strings.Join(matches.CVE.ProblemTypes(), cfg.outRecSep),
+				cfg.descriptionAt-1, matches.CVE.Description(),
 				cfg.cvss2at-1, fmt.Sprintf("%.1f", matches.CVE.CVSS20base()),
 				cfg.cvss3at-1, fmt.Sprintf("%.1f", matches.CVE.CVSS30base()),
 				cfg.cvssAt-1, fmt.Sprintf("%.1f", cvss),

--- a/cvefeed/nvdcommon/nvdcommon.go
+++ b/cvefeed/nvdcommon/nvdcommon.go
@@ -38,6 +38,7 @@ type CVEItem interface {
 	CVEID() string
 	Config() []LogicalTest
 	ProblemTypes() []string
+	Description() string
 	CVSS20base() float64
 	CVSS30base() float64
 }
@@ -85,6 +86,7 @@ func MergeCVEItems(x, y CVEItem) CVEItem {
 	z := mergeCVEItem{
 		id:           x.CVEID(),
 		problemTypes: cwes,
+		description:  x.Description(),
 		cvss20base:   cvss20,
 		cvss30base:   cvss30,
 		config:       []LogicalTest{mergeOp},
@@ -97,6 +99,7 @@ type mergeCVEItem struct {
 	id                     string
 	config                 []LogicalTest
 	problemTypes           []string
+	description            string
 	cvss20base, cvss30base float64
 }
 
@@ -110,6 +113,10 @@ func (i mergeCVEItem) Config() []LogicalTest {
 
 func (i mergeCVEItem) ProblemTypes() []string {
 	return i.problemTypes
+}
+
+func (i mergeCVEItem) Description() string {
+	return i.description
 }
 
 func (i mergeCVEItem) CVSS20base() float64 {

--- a/cvefeed/nvdjson/interfaces.go
+++ b/cvefeed/nvdjson/interfaces.go
@@ -106,7 +106,7 @@ func (i *cveItem) ProblemTypes() []string {
 	return cwes
 }
 
-// Description returns English written description of vulnerability
+// Description returns plain-text description of vulnerability
 func (i *cveItem) Description() string {
 	for _, dsc := range i.cveItem.CVE.Description.DescriptionData {
 		return dsc.Value

--- a/cvefeed/nvdjson/interfaces.go
+++ b/cvefeed/nvdjson/interfaces.go
@@ -106,6 +106,14 @@ func (i *cveItem) ProblemTypes() []string {
 	return cwes
 }
 
+// Description returns English written description of vulnerability
+func (i *cveItem) Description() string {
+	for _, dsc := range i.cveItem.CVE.Description.DescriptionData {
+		return dsc.Value
+	}
+	return ""
+}
+
 // CVSS20base returns CVSS 2.0 base score of vulnerability
 func (i *cveItem) CVSS20base() float64 {
 	if i.cveItem.Impact != nil && i.cveItem.Impact.BaseMetricV2 != nil && i.cveItem.Impact.BaseMetricV2.CVSSV2 != nil {


### PR DESCRIPTION
Allows the description of the vulnerability to be displayed in addition
to the options already available (identifier, severity, etc.)