### PR TITLE
[cpe2cve] specify in howto that -idxd can be used with rpm2cpe results

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -23,7 +23,7 @@ Finally, use the [cpe2cve](https://github.com/facebookincubator/nvdtools/tree/ma
 ```bash
 rpm -qa | \
 rpm2cpe -rpm=1 -cpe=2 | \
-cpe2cve -cpe=2 -cve=3 -cwe=4 -feed=json /tmp/nvd/*.json.gz
+cpe2cve -cpe=2 -cve=3 -cwe=4 -idxd -feed=json /tmp/nvd/*.json.gz
 ```
 
 The command above process each CPE individually and prints their respective CVEs. However, it's not uncommon in the NVD database to have more elaborate CVEs which affect a combination of CPEs, e.g. if A and B and not C. For this case, you could group your CPEs per host, for example, and process them in a single batch:


### PR DESCRIPTION
As explained in https://github.com/facebookincubator/nvdtools/issues/71.