### PR TITLE
[build] change build name to usharesoft-nvdtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+release/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NAME = nvdtools
+NAME = usharesoft-nvdtools
 VERSION = tip
 
 TOOLS = \

--- a/rpm/nvdtools.spec
+++ b/rpm/nvdtools.spec
@@ -1,11 +1,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-Name: nvdtools
+Name: usharesoft-nvdtools
 Summary: A collection of tools for working with National Vulnerability Database feeds.
 Version: %{_version}
 Release: 1
 License: Apache License 2.0
-URL: https://github.com/facebookincubator/nvdtools
+URL: https://github.com/usharesoft/nvdtools
 Source0: %{name}-%{version}.tar.gz
 
 %description


### PR DESCRIPTION
This commit changes name used in build process, usharesoft-nvdtools
instead of nvdtools.

RPM can be build in release folder with the following command (and with
appropriate GOPATH environment variable):

    make distclean release_rpm VERSION=1.0